### PR TITLE
consolidate RUN commands, and add a cargo clean step

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,24 +5,27 @@ RUN mkdir /app /config
 WORKDIR /app
 
 # Install needed packages
-RUN apt-get update
-RUN apt-get install -y python3-virtualenv python3-pip default-mysql-client
+RUN apt-get update && apt-get install -y \
+    python3-virtualenv \
+    python3-pip \
+    default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
 
 # Clone syncstorage-rs and build it
-RUN git clone https://github.com/mozilla-services/syncstorage-rs ./
-RUN cargo install --path ./syncserver --no-default-features --features=syncstorage-db/mysql --locked
-RUN cargo install diesel_cli --no-default-features --features 'mysql'
+RUN git clone https://github.com/mozilla-services/syncstorage-rs ./ \
+    && cargo install --path ./syncserver --no-default-features --features=syncstorage-db/mysql --locked \
+    && cargo install diesel_cli --no-default-features --features 'mysql' \
+    && cargo clean
 
 # Setup the Python venv
-RUN virtualenv venv
-RUN /app/venv/bin/pip install -r requirements.txt
-RUN /app/venv/bin/pip install -r tools/tokenserver/requirements.txt
-RUN /app/venv/bin/pip install pyopenssl==22.1.0
+RUN virtualenv venv \
+    && /app/venv/bin/pip install -r requirements.txt \
+    && /app/venv/bin/pip install -r tools/tokenserver/requirements.txt \
+    && /app/venv/bin/pip install pyopenssl==22.1.0
 
 # Cleanup
 RUN rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Copy entrypoint script and set it
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 entrypoint.sh /
 ENTRYPOINT /entrypoint.sh


### PR DESCRIPTION
- Add a `cargo clean` step after the `cargo install` commands, to reduce on-disk size
- Consolidate RUN commands to reduce the [number of intermediate images](https://docs.docker.com/reference/dockerfile/#run) and [avoid caching issues](https://docs.docker.com/build/building/best-practices/#run)

These changes took the overall image size from 3.68G to 2.26G.