### PR TITLE
Update volume paths and port mappings in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,9 @@ services:
     image: linuxserver/mariadb:10.6.13
     volumes:
       - ${MARIADB_DATA_PATH:-./data/config}:/config
-      - ${MARIADB_INIT_PATH:-./data/initdb.d/init.sql}:/config/initdb.d/init.sql
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: syncstorage
+      MYSQL_DATABASE: syncstorage_rs
       MYSQL_USER: sync
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -26,5 +25,5 @@ services:
       SYNC_CAPACITY: 10
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
-      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
-      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs
+      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled
+      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,9 @@ services:
     container_name: firefox_mariadb
     image: linuxserver/mariadb:10.6.13
     volumes:
-      - ./data/config:/config
-      - ./data/initdb.d/init.sql:/config/initdb.d/init.sql
+      # Optional volume path for MariaDB config/data
+      - ${MARIADB_DATA_PATH:-./data/config}:/config
+      - ${MARIADB_INIT_PATH:-./data/initdb.d/init.sql}:/config/initdb.d/init.sql
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: syncstorage
@@ -17,14 +18,16 @@ services:
     build: ./app/
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      # Optional outbound (host) port mapping
+      - "${SYNCSERVER_HOST_PORT:-8000}:8000"
     depends_on:
       - mariadb
     environment:
       LOGLEVEL: info
       SYNC_URL: ${SYNC_URL}
-      SYNC_CAPACITY: 10 # Max number of users that will be accepted
+      SYNC_CAPACITY: 10
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
+      # Update these to match the SYNC_URL if the port changes
       SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
       SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,12 +20,12 @@ services:
       - "${SYNCSERVER_HOST_PORT:-5300}:8000"
     depends_on:
       - mariadb
-    environment:
+  environment:
       RUST_LOG: info
       RUST_BACKTRACE: 1
       SYNC_URL: ${SYNC_URL:-http://192.168.178.57:5300}
       SYNC_CAPACITY: 10
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
-      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
-      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
+      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled
+      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - ${MARIADB_INIT_PATH:-./data/initdb.d/init.sql}:/config/initdb.d/init.sql
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: syncstorage_rs
+      MYSQL_DATABASE: syncstorage
       MYSQL_USER: sync
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -17,14 +17,14 @@ services:
     build: ./app/
     restart: unless-stopped
     ports:
-      - "${SYNCSERVER_HOST_PORT:-5300}:8000"
+      - "${SYNCSERVER_HOST_PORT:-8000}:8000"
     depends_on:
       - mariadb
     environment:
       LOGLEVEL: info
       SYNC_URL: ${SYNC_URL}
-      SYNC_CAPACITY: 10 # Max number of users that will be accepted
+      SYNC_CAPACITY: 10
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
-      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled
-      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs?ssl-mode=disabled
+      SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
+      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,12 +3,11 @@ services:
     container_name: firefox_mariadb
     image: linuxserver/mariadb:10.6.13
     volumes:
-      # Optional volume path for MariaDB config/data
       - ${MARIADB_DATA_PATH:-./data/config}:/config
       - ${MARIADB_INIT_PATH:-./data/initdb.d/init.sql}:/config/initdb.d/init.sql
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: syncstorage
+      MYSQL_DATABASE: syncstorage_rs
       MYSQL_USER: sync
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -18,16 +17,15 @@ services:
     build: ./app/
     restart: unless-stopped
     ports:
-      # Optional outbound (host) port mapping
-      - "${SYNCSERVER_HOST_PORT:-8000}:8000"
+      - "${SYNCSERVER_HOST_PORT:-5300}:8000"
     depends_on:
       - mariadb
     environment:
-      LOGLEVEL: info
-      SYNC_URL: ${SYNC_URL}
+      RUST_LOG: info
+      RUST_BACKTRACE: 1
+      SYNC_URL: ${SYNC_URL:-http://192.168.178.57:5300}
       SYNC_CAPACITY: 10
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
-      # Update these to match the SYNC_URL if the port changes
       SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs
-      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs
+      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,11 +21,10 @@ services:
     depends_on:
       - mariadb
   environment:
-      RUST_LOG: info
-      RUST_BACKTRACE: 1
-      SYNC_URL: ${SYNC_URL:-http://192.168.178.57:5300}
-      SYNC_CAPACITY: 10
+      LOGLEVEL: info
+      SYNC_URL: ${SYNC_URL}
+      SYNC_CAPACITY: 10 # Max number of users that will be accepted
       SYNC_MASTER_SECRET: ${SYNC_MASTER_SECRET}
       METRICS_HASH_SECRET: ${METRICS_HASH_SECRET}
       SYNC_SYNCSTORAGE_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled
-      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/syncstorage_rs?ssl-mode=disabled
+      SYNC_TOKENSERVER_DATABASE_URL: mysql://sync:${MYSQL_PASSWORD}@mariadb:3306/tokenserver_rs?ssl-mode=disabled

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - "${SYNCSERVER_HOST_PORT:-5300}:8000"
     depends_on:
       - mariadb
-  environment:
+    environment:
       LOGLEVEL: info
       SYNC_URL: ${SYNC_URL}
       SYNC_CAPACITY: 10 # Max number of users that will be accepted


### PR DESCRIPTION
Hi there,
im trying to use your awesome project for my needs
but i have a very specific workflow for my containers and volumes and wanted to add the following flexibility:
Make syncserver-port and mount-volume paths optionally be configurable through env vars