### PR TITLE
accommodate pip->poetry upstream

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,5 @@
 from rust:latest
 
-ARG GIT_COMMIT=1dc421474df2a4ee973d529534cd0eb7189d58ce
-
 # Create needed directories
 RUN mkdir /app /config
 WORKDIR /app
@@ -16,14 +14,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Clone syncstorage-rs and build it
 RUN git clone https://github.com/mozilla-services/syncstorage-rs ./ \
-    && git checkout ${GIT_COMMIT} \
     && cargo install --path ./syncserver --no-default-features --features=syncstorage-db/mysql --locked \
     && cargo install diesel_cli --no-default-features --features 'mysql' \
     && cargo clean
 
 # Setup the Python venv
 RUN virtualenv venv \
-    && /app/venv/bin/pip install -r requirements.txt \
+    && /app/venv/bin/pip3 install flake8 hawkauthlib konfig pyramid pyramid_hawkauth requests simplejson unittest2 WebTest WSGIProxy2 poetry \
+    && /app/venv/bin/poetry self add poetry-plugin-export \
+    && /app/venv/bin/poetry install --without dev --with tokenserver-unit-tests --no-interaction --no-ansi \
     && /app/venv/bin/pip install -r tools/tokenserver/requirements.txt \
     && /app/venv/bin/pip install pyopenssl==22.1.0
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -4,7 +4,7 @@ sleep 5
 
 # First run all migrations
 /usr/local/cargo/bin/diesel --database-url "${SYNC_SYNCSTORAGE_DATABASE_URL}" migration --migration-dir syncstorage-mysql/migrations run
-/usr/local/cargo/bin/diesel --database-url "${SYNC_TOKENSERVER_DATABASE_URL}" migration --migration-dir tokenserver-db/migrations run
+/usr/local/cargo/bin/diesel --database-url "${SYNC_TOKENSERVER_DATABASE_URL}" migration --migration-dir tokenserver-mysql/migrations run
 
 # Parse token server database URL
 proto="$(echo $SYNC_TOKENSERVER_DATABASE_URL | grep :// | sed -e's,^\(.*://\).*,\1,g')"


### PR DESCRIPTION
Previously worked around in https://github.com/dan-r/syncstorage-rs-docker/issues/9

Here is the upstream refactor commit, where they switched from a pip requirements.txt to a poetry pyproject.toml.
https://github.com/mozilla-services/syncstorage-rs/commit/f8715d4e916e5f3ef5431cb40ecdebd71b21fa7d#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47

I borrowed their CI commands, and now it builds successfully.